### PR TITLE
PSTORE-681: Gigya Extension Throwing Exception on Category Pages

### DIFF
--- a/app/design/frontend/base/default/layout/aagigya.xml
+++ b/app/design/frontend/base/default/layout/aagigya.xml
@@ -162,7 +162,7 @@
     </catalog_product_view>
     <catalog_category_default>
         <reference name="content">
-            <block name="product_list">
+            <block type="catalog/product_list" name="product_list">
                 <action method="addReviewSummaryTemplate">
                     <type>short</type>
                     <template>gigya/ratings/summary_short.phtml</template>
@@ -172,7 +172,7 @@
     </catalog_category_default>
     <catalog_category_layered>
         <reference name="content">
-            <block name="product_list">
+            <block type="catalog/product_list" name="product_list">
                 <action method="addReviewSummaryTemplate">
                     <type>short</type>
                     <template>gigya/ratings/summary_short.phtml</template>


### PR DESCRIPTION
The exception.log on the Store server is being filled with this exception:


{noformat}
2017-07-18T19:15:56+00:00 ERR (3): 
exception 'Mage_Core_Exception' with message 'Invalid block type: ' in /home/purina_store/live_2017-07-03_1539/app/Mage.php:595
Stack trace:
#0 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Model/Layout.php(495): Mage::throwException('Invalid block t...')
#1 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Model/Layout.php(437): Mage_Core_Model_Layout->_getBlockInstance('', Array)
#2 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Model/Layout.php(472): Mage_Core_Model_Layout->createBlock('', 'product_list')
#3 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Model/Layout.php(239): Mage_Core_Model_Layout->addBlock('', 'product_list')
#4 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Model/Layout.php(205): Mage_Core_Model_Layout->_generateBlock(Object(Mage_Core_Model_Layout_Element), Object(Mage_Core_Model_Layout_Element))
#5 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Model/Layout.php(210): Mage_Core_Model_Layout->generateBlocks(Object(Mage_Core_Model_Layout_Element))
#6 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Controller/Varien/Action.php(344): Mage_Core_Model_Layout->generateBlocks()
#7 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Catalog/controllers/CategoryController.php(148): Mage_Core_Controller_Varien_Action->generateLayoutBlocks()
#8 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Controller/Varien/Action.php(418): Mage_Catalog_CategoryController->viewAction()
#9 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(254): Mage_Core_Controller_Varien_Action->dispatch('view')
#10 /home/purina_store/live_2017-07-03_1539/app/code/local/DigitalEvolution/Core/Router/Standard.php(78): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#11 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Controller/Varien/Front.php(172): DigitalEvolution_Core_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#12 /home/purina_store/live_2017-07-03_1539/app/code/core/Mage/Core/Model/App.php(365): Mage_Core_Controller_Varien_Front->dispatch()
#13 /home/purina_store/live_2017-07-03_1539/app/Mage.php(684): Mage_Core_Model_App->run(Array)
#14 /home/purina_store/live_2017-07-03_1539/index.php(83): Mage::run('', 'store')
#15 {main}
{noformat}


The issue is a non-typed block in Gigya. The reviews still display on the category page but the exception is thrown.